### PR TITLE
fix: bundle by replacing BrowserRouter with HashRouter and fix typecker

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 //import Versions from './components/Versions'
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
+import { HashRouter as Router, Route, Routes } from 'react-router-dom'
 import SearchBar from './pages/SearchBar'
 import Create from './pages/Create'
 

--- a/src/renderer/src/hooks/UseListSnippets.tsx
+++ b/src/renderer/src/hooks/UseListSnippets.tsx
@@ -23,7 +23,7 @@ export const useListSnippets = (): ResponseType => {
     try {
       window.electron.ipcRenderer.send('list-snippets')
 
-      window.api.listSnippetsResponse((event: any, responseData: any) => {
+      window.api.listSnippetsResponse((_event: any, responseData: any) => {
         if (responseData.status === 'success') {
           setResponse({ ...response, data: responseData.message as DataType[], loading: false })
         } else {

--- a/src/renderer/src/hooks/useCreateSnippet.tsx
+++ b/src/renderer/src/hooks/useCreateSnippet.tsx
@@ -19,13 +19,13 @@ export const useCreateSnippet = (): [(data: SnippetDataType) => void, ResponseTy
     loading: false
   })
 
-  const createSnippet = (form: SnippetDataType) => {
+  const createSnippet = (form: SnippetDataType): void => {
     setResponse({ ...response, loading: true })
 
     try {
       window.electron.ipcRenderer.send('create-snippet', form)
 
-      window.api.createSnippetResponse((event: any, response: any) => {
+      window.api.createSnippetResponse((_event: any, response: any) => {
         if (response.status === 'success') {
           setResponse({ ...response, loading: true })
         } else {


### PR DESCRIPTION
## WHAT:

This PR fixes some type-check which were preventing to propely build the app. Also there was a problem with the use of `BrowserRouter` that broke the build. Here I found the issue and how to solve it 😉 https://stackoverflow.com/questions/76384528/electron-vite-preview-showing-blank-screen