### PR TITLE
feat: defining gray colors

### DIFF
--- a/src/renderer/src/components/Dropdown/index.tsx
+++ b/src/renderer/src/components/Dropdown/index.tsx
@@ -40,16 +40,18 @@ const Dropdown = ({ onSelect, options }: Props): JSX.Element => {
   }, [selectedIndex])
 
   return (
-    <div className="z-10 bg-gray-800 rounded-lg shadow w-60 dark:bg-gray-700 absolute">
-      <ul className="h-48 py-2 overflow-y-auto" aria-labelledby="dropdownUsersButton">
+    <div className="z-10 bg-gray-700 rounded-lg shadow w-60 dark:bg-gray-700 absolute border border-gray-600 mt-2">
+      <ul className="grid gap-1 p-1 overflow-hidden max-h-48">
         {options.map((tag, index) => (
           <li
-            ref={(el) => (rowRefs.current[index] = el)}
             key={index}
+            ref={(el) => (rowRefs.current[index] = el)}
             className={
-              'hover:bg-gray-600 ' + (selectedIndex === index ? 'bg-gray-700' : 'bg-gray-800')
+              'rounded-lg hover:bg-gray-800 h-min ' +
+              (selectedIndex === index ? 'bg-gray-800' : 'bg-gray-700')
             }
-            onClick={() => onSelect(tag)}
+            onClick={() => onSelect(options[selectedIndex])}
+            onMouseOver={() => setSelectedIndex(index)}
           >
             <span className={'flex justify-between items-center p-2'}>{tag}</span>
           </li>

--- a/src/renderer/src/components/Footer/index.tsx
+++ b/src/renderer/src/components/Footer/index.tsx
@@ -7,8 +7,8 @@ function Footer({
 }): JSX.Element {
   return (
     <div className="fixed bottom-2 left-0 w-full px-4">
-      {topBorder && <hr className="border-gray-600 pb-2" />}
-      <div className="px-4">{tempText}</div>
+      {topBorder && <hr className="border-gray-700 pb-2" />}
+      <div className="px-4 text-gray-400">{tempText}</div>
     </div>
   )
 }

--- a/src/renderer/src/components/Header/index.tsx
+++ b/src/renderer/src/components/Header/index.tsx
@@ -11,9 +11,9 @@ const Header = ({ tempText }: { tempText: string }): JSX.Element => {
           <Icon name="arrow-left" size="large" />
         </div>
 
-        <span className="text-gray-600 dark:text-gray-400">{tempText}</span>
+        <span className="text-gray-200 dark:text-gray-400">{tempText}</span>
       </div>
-      <hr className="border-gray-600" />
+      <hr className="border-gray-700" />
     </div>
   )
 }

--- a/src/renderer/src/components/SearchBarCode/index.tsx
+++ b/src/renderer/src/components/SearchBarCode/index.tsx
@@ -1,4 +1,4 @@
-import Tag from '../atoms/Tag'
+import Tag from '@renderer/components/atoms/Tag'
 
 interface Props {
   labels: string[]
@@ -7,7 +7,7 @@ interface Props {
 
 const SearchBarCode = ({ labels, code }: Props): JSX.Element => {
   return (
-    <div className="bg-gray-800 w-full px-4 py-2">
+    <div className="bg-gray-900 w-full px-4 py-2">
       <div>
         <div className="flex flex-row gap-2 items-center">
           {labels.map((label, index) => {
@@ -19,12 +19,8 @@ const SearchBarCode = ({ labels, code }: Props): JSX.Element => {
           })}
         </div>
       </div>
-      <div className="w-full h-[250px] mt-2 bg-black p-2 rounded-lg">
-        <textarea
-          className="bg-black h-full text-sm block w-full outline-none p-2 resize-none"
-          value={code || ''}
-          disabled
-        />
+      <div className="w-full h-[250px] mt-2 bg-gray-700 text-white border border-gray-600 p-2 rounded-lg">
+        {code}
       </div>
     </div>
   )

--- a/src/renderer/src/components/SearchBarHeader/index.tsx
+++ b/src/renderer/src/components/SearchBarHeader/index.tsx
@@ -15,7 +15,7 @@ const SearchBarHeader = ({ query, setQuery }: Props): JSX.Element => {
         <input
           type="text"
           autoFocus
-          className="no-draggable text-gray-600 dark:text-gray-400 outline-none w-6/12 bg-inherit placeholder-gray-500"
+          className="no-draggable text-white outline-none w-6/12 bg-inherit placeholder-gray-200"
           placeholder={t('search_bar.placeholder')}
           value={query}
           onChange={(e) => setQuery(e.target.value)}

--- a/src/renderer/src/components/SearchBarRow/index.tsx
+++ b/src/renderer/src/components/SearchBarRow/index.tsx
@@ -22,11 +22,11 @@ const SearchBarRow = ({
   return (
     <div
       key={index}
-      className={`flex justify-between items-center cursor-pointer mx-4 px-4 py-2 rounded-lg ${selectedIndex == index ? 'bg-gray-800' : ''}`}
+      className={`flex justify-between items-center cursor-pointer mx-4 px-4 py-2 rounded-lg ${selectedIndex == index ? 'bg-gray-700' : ''}`}
       onClick={() => setShowCode(!showCode)}
       onMouseOver={() => setSelectedIndex(index)}
     >
-      <div className={`flex items-center space-x-2 my-1`}>
+      <div className={`flex text-white teitems-center space-x-2 my-1`}>
         <span>{title}</span>
       </div>
 

--- a/src/renderer/src/components/atoms/Icon/index.tsx
+++ b/src/renderer/src/components/atoms/Icon/index.tsx
@@ -54,7 +54,7 @@ const Icon = ({ name, size = 'medium', stroke = 3 }: Props): JSX.Element => {
       viewBox="0 0 24 24"
       stroke="currentColor"
       strokeWidth={stroke}
-      className={`${sizes[size]} ${strokes[stroke]}`}
+      className={`${sizes[size]} ${strokes[stroke]} text-white`}
     >
       <Content name={name} />
     </svg>

--- a/src/renderer/src/components/atoms/Input/index.tsx
+++ b/src/renderer/src/components/atoms/Input/index.tsx
@@ -9,7 +9,7 @@ const LabeledInput = ({ value, placeholder, onChange, required = false }: Props)
   return (
     <input
       type="text"
-      className="bg-gray-800 border border-gray-900 text-sm rounded-lg block w-full p-2.5 outline-none placeholder:text-gray-600"
+      className="bg-gray-700 border border-gray-600 text-sm rounded-lg block w-full p-2.5 outline-none placeholder:text-gray-300"
       placeholder={placeholder}
       value={value}
       onChange={onChange}

--- a/src/renderer/src/components/atoms/TextArea/index.tsx
+++ b/src/renderer/src/components/atoms/TextArea/index.tsx
@@ -1,19 +1,27 @@
 type Props = {
   value: string
-  placeholder: string
-  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
+  placeholder?: string
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
   required?: boolean
+  disabled?: boolean
 }
 
-const TextArea = ({ value, placeholder, onChange, required = false }: Props): JSX.Element => {
+const TextArea = ({
+  value,
+  placeholder,
+  onChange,
+  required = false,
+  disabled = false
+}: Props): JSX.Element => {
   return (
     <textarea
       rows={4}
-      className="bg-gray-800 border border-gray-900 text-sm rounded-lg block w-full p-2.5 outline-none placeholder:text-gray-600"
+      className="bg-gray-700 border border-gray-600 text-sm rounded-lg block w-full p-2.5 outline-none placeholder:text-gray-300"
       placeholder={placeholder}
       value={value}
       onChange={onChange}
       required={required}
+      disabled={disabled}
     />
   )
 }

--- a/src/renderer/src/components/molecules/TagPicker/index.tsx
+++ b/src/renderer/src/components/molecules/TagPicker/index.tsx
@@ -2,6 +2,7 @@ import { createRef, useEffect, useState } from 'react'
 import Dropdown from '@renderer/components/Dropdown'
 import Tag from '@renderer/components/atoms/Tag'
 import Icon from '@renderer/components/atoms/Icon'
+import Label from '@renderer/components/atoms/Label'
 
 type Props = {
   label: string
@@ -50,8 +51,8 @@ const TagPicker = ({
 
   return (
     <div>
-      <label className="block mb-2 text-sm font-medium dark:text-white">{label}</label>
-      <div className="flex flex-row justify-between items-center bg-gray-800 border border-gray-900 text-sm rounded-lg block w-full px-4 py-2 outline-none gap-2">
+      <Label>{label}</Label>
+      <div className="flex flex-row justify-between items-center bg-gray-700 border border-gray-600 text-sm rounded-lg block w-full px-4 py-2 outline-none gap-2">
         {hasTags && (
           <div className="flex flex-row flex-wrap align-middle gap-2">
             {values.slice(0, 2).map((tag, index) => (
@@ -70,7 +71,7 @@ const TagPicker = ({
           onFocus={() => setIsDropdownOpen(true)}
           onBlur={() => setIsDropdownOpen(false)}
           required
-          className="bg-inherit outline-none w-full placeholder:text-gray-600"
+          className="bg-inherit outline-none w-full placeholder:text-gray-50"
         />
 
         <div onClick={() => setIsDropdownOpen(!isDropdownOpen)}>

--- a/src/renderer/src/pages/Create/index.tsx
+++ b/src/renderer/src/pages/Create/index.tsx
@@ -44,12 +44,12 @@ function Create(): JSX.Element {
   }
 
   return (
-    <div className="fixed w-full left-0 top-0">
+    <div className="fixed w-full h-full left-0 top-0 bg-gray-800 border border-gray-700">
       <Header tempText={'Save code'} />
       <div className="p-4 gap-12">
         <form onSubmit={submit}>
-          <div className="gap-12">
-            <div className="grid grid-cols-2 gap-2">
+          <div className="grid gap-4">
+            <div className="grid grid-cols-2 gap-3">
               <LabeledInput
                 label={t('create.fields.name.label')}
                 placeholder={t('create.fields.name.label')}

--- a/src/renderer/src/pages/SearchBar/index.tsx
+++ b/src/renderer/src/pages/SearchBar/index.tsx
@@ -91,13 +91,13 @@ function SearchBar(): JSX.Element {
 
   return (
     <>
-      <div className="fixed w-full left-0 top-0">
+      <div className="fixed w-full h-full left-0 top-0 bg-gray-800">
         <SearchBarHeader query={query} setQuery={setQuery} />
         {query && (
           <>
-            <hr className="border-gray-600" />
+            <hr className="border-gray-700" />
             <div className={`w-full h-[301px] text-gray-300 ${showCode ? 'grid grid-cols-2' : ''}`}>
-              <div className="mt-2 h-[297px] overflow-y-scroll">
+              <div className="mt-2 h-[297px] overflow-hidden">
                 {results.map((result, index) => (
                   <div key={index} ref={(el) => (rowRefs.current[index] = el)}>
                     <SearchBarRow

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,24 @@
 /** @type {import('tailwindcss').Config} */
+
 module.exports = {
   content: ['./src/renderer/src/**/*.{html,js,jsx,ts,tsx}'],
   theme: {
-    extend: {}
+    extend: {
+      colors: {
+        gray: {
+          50: '#F9F9FB',
+          100: '#D9D9E0',
+          200: '#B8BAC5',
+          300: '#989AAB',
+          400: '#777B90',
+          500: '#575B75',
+          600: '#42455A',
+          700: '#2D303E',
+          800: '#181A23',
+          900: '#0B0C12'
+        }
+      }
+    }
   },
   plugins: []
 }


### PR DESCRIPTION
### What?
Defining colors according to the design. Also, improving a little the TagPicker.
<img width="387" alt="image" src="https://github.com/user-attachments/assets/b5400be5-c711-4144-b92b-078753c37984">



**Before**
<img width="771" alt="image" src="https://github.com/user-attachments/assets/bea936bc-050c-4ad0-8ab6-ce467717146a">
**After**
<img width="783" alt="image" src="https://github.com/user-attachments/assets/2ff11937-0fe5-473f-9d17-e5d929007a46">

**Before**
<img width="770" alt="image" src="https://github.com/user-attachments/assets/7b20bd86-0469-40c2-a936-f8e085f6730b">
**After**
<img width="774" alt="image" src="https://github.com/user-attachments/assets/e66b5473-0646-4ff5-a290-08e10d539622">

**Before**
<img width="773" alt="image" src="https://github.com/user-attachments/assets/211d4517-4285-4bff-84af-5815beba50dc">
**After**
<img width="771" alt="image" src="https://github.com/user-attachments/assets/848735ce-ff6c-40c4-8f96-384f2af83149">
