### PR TITLE
feat: close on blur, with escape and footer draggable

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -96,6 +96,14 @@ function createWindow(): void {
     app.exit()
   })
 
+  mainWindow.on('blur', () => {
+    mainWindow.hide()
+  })
+
+  ipcMain.on('hide-window', () => {
+    mainWindow.hide()
+  })
+
   ipcMain.on('resize-window', (_event, size) => {
     switch (size) {
       case 'small': {

--- a/src/renderer/src/components/Footer/Action/index.tsx
+++ b/src/renderer/src/components/Footer/Action/index.tsx
@@ -26,7 +26,7 @@ const Action = ({ action }: { action: ActionType }): JSX.Element => {
 
   return (
     <div
-      className="flex flex-row gap-2 content-center p-0.5 pr-4 rounded-lg hover:cursor-pointer border bg-gray-800 border-gray-800 hover:bg-gray-700 active:bg-gray-900 active:border active:border-accent"
+      className="flex flex-row gap-2 content-center p-0.5 pr-4 rounded-lg hover:cursor-pointer border bg-gray-800 border-gray-800 hover:bg-gray-700 active:bg-gray-900 active:border active:border-accent no-draggable"
       onClick={callback}
     >
       <div className="flex flex-row gap-0.5">

--- a/src/renderer/src/components/Footer/index.tsx
+++ b/src/renderer/src/components/Footer/index.tsx
@@ -12,7 +12,7 @@ const Footer = ({ actions }: Props): JSX.Element => {
   useActionKeyBindings(actions)
 
   return (
-    <div className="fixed bottom-0 w-full left-0 bg-gray-800">
+    <div className="fixed bottom-0 w-full left-0 bg-gray-800 draggable">
       <hr className="border-gray-700" />
       <div className="grid grid-cols-2 place-content-between py-1 px-6">
         <div className="flex flex-row gap-2 place-content-start">

--- a/src/renderer/src/hooks/useKeyBindings.tsx
+++ b/src/renderer/src/hooks/useKeyBindings.tsx
@@ -20,6 +20,8 @@ export const useKeyBindings = (props: KeyBinding[]): void => {
     currentlyPressedKeys.add(e.key)
     props.forEach((binding) => {
       if (areAllKeyPressed(binding.cmd)) {
+        // Clear the keys so that the next key press can be detected
+        currentlyPressedKeys.clear()
         binding.callback()
       }
     })

--- a/src/renderer/src/pages/SearchBar/index.tsx
+++ b/src/renderer/src/pages/SearchBar/index.tsx
@@ -81,6 +81,12 @@ function SearchBar(): JSX.Element {
   const actions: ActionType[] = !query
     ? [
         {
+          label: '',
+          keyboardKeys: ['Escape'],
+          hidden: true,
+          callback: (): void => window.electron.ipcRenderer.send('hide-window')
+        },
+        {
           label: t('actions.for_actions'),
           keyboardKeys: ['Slash'],
           callback: (): void => setQuery('/')


### PR DESCRIPTION
### What?
Adding improvements:
- Hide window on blur, clicking on the background.
- Hide window on click Escape from the search bar without query.
- Making the footer draggable (only parts without actions)