### PR TITLE
hotfix: avoid show code with no items

### DIFF
--- a/src/renderer/src/pages/SearchBar/index.tsx
+++ b/src/renderer/src/pages/SearchBar/index.tsx
@@ -73,7 +73,7 @@ function SearchBar(): JSX.Element {
         navigate('/create')
         break
       default:
-        if (filteredData.length > 0) setSelectedIndex(0)
+        filteredData.length > 0 ? setSelectedIndex(0) : setSelectedIndex(-1)
         window.electron.ipcRenderer.send('resize-window', 'big')
     }
   }, [query])


### PR DESCRIPTION
### What & Why?
Until now, when we were searching by a query with no results and we tried to show the code, the app crashed because it was trying to show an unexpected item (index: 0), now, if there are no items, we set the index -1 to avoid show the code.

#### Before
<img width="769" alt="image" src="https://github.com/user-attachments/assets/259c5fd5-e12f-4f04-b779-9ee1c1b8c03f">


#### After
<img width="772" alt="image" src="https://github.com/user-attachments/assets/5561962e-42c6-4342-9ffe-30549af2b9de">
