### PR TITLE
[Fix] empty inputValue on blur

### DIFF
--- a/src/renderer/src/components/molecules/TagPicker/index.tsx
+++ b/src/renderer/src/components/molecules/TagPicker/index.tsx
@@ -85,7 +85,7 @@ const TagPicker = ({
             // Using setTimeout to prevent the dropdown from closing when clicking on it (blur event)
             onBlur={() => {
               timeout = setTimeout(() => setIsDropdownOpen(false), 500)
-              if (inputValue) addTag({ title: inputValue } as Label)
+              if (inputValue && options.length === 0) addTag({ title: inputValue } as Label)
             }}
             required
             className="bg-inherit outline-none w-full placeholder:text-gray-50 min-w-0.5"


### PR DESCRIPTION
ISSUE: When you write something on label input and click on a option, the input become in the tag, not the clicked one

now the clicked is the first one