### PR TITLE
add dependant bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      timezone: Europe/Madrid
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## 🚪 Why
Enable automatisation on dependencies

## 🔑 What

This PR includes initial dependabot config for github.